### PR TITLE
Displaying validation "Last reminder should be getter Greater than Se…

### DIFF
--- a/includes/fluentIntegration.php
+++ b/includes/fluentIntegration.php
@@ -259,7 +259,7 @@ class esigFluent extends IntegrationManager
                 }elseif(empty($second_reminder_email)){
                     $errors[] = 'Please enter Second Reminder';
                 }elseif(empty($expire_reminder)){
-                    $errors[] = 'Please enter Third Reminder ';
+                    $errors[] = 'Please enter Last Reminder ';
                 } 
 
                
@@ -268,7 +268,7 @@ class esigFluent extends IntegrationManager
                 }
                 
                 if ($expire_reminder <= $second_reminder_email ){
-                    $errors[] = 'Last reminder should be getter Greater than Second reminder';
+                    $errors[] = 'Last reminder should be Greater than Second reminder';
                 }	
                 
 


### PR DESCRIPTION
…cond reminder" message if we added Second Reminder greater than Last Reminder on "Add New WP E-Signature Integration Feed" pop up in case of "Fluent" form