### PR TITLE
TRL-1565: Add Fluent Forms document title shortcode support

### DIFF
--- a/admin/esig-fluent-filters.php
+++ b/admin/esig-fluent-filters.php
@@ -12,9 +12,18 @@ if (!class_exists('esigFluentFilters')):
 
         protected static $instance = null;
 
+        /**
+         * Initialize Fluent Forms document filters.
+         *
+         * @since 2.0.3
+         * @access private
+         *
+         * @return void
+         */
         private function __construct() {
             
             // render gravity shortcode to replace with value. 
+           add_filter("esig_document_title_filter", array($this, "fluent_document_title_filter"), 10, 2);
            add_filter("esig_document_clone_render_content", array($this, "document_content_render"), 10, 4);
 
         }
@@ -24,6 +33,7 @@ if (!class_exists('esigFluentFilters')):
          *  replaced with new new content with shortcode content. 
          *  @since 1.5.6.8
          *  @param string $content | Content of document to replace
+         *  @param array  $args    Document render arguments.
          *  @return string $content 
          */
 
@@ -42,12 +52,127 @@ if (!class_exists('esigFluentFilters')):
 
             //ESIG_GF_VALUE::setEntryID(esigget("entryId", $args));
 
+            // phpcs:ignore PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnCallbackFunctions -- WordPress shortcode regex must dispatch through the core do_shortcode_tag callback.
             $content = preg_replace_callback("/$pattern/", 'do_shortcode_tag', $content);
             
             // Always restore square braces so we don't break things like <!--[if IE ]>
             $content = unescape_invalid_shortcodes($content);
 
             return $content;
+        }
+
+        /**
+         * Replace Fluent Forms field placeholders in the document title.
+         *
+         * Supports the {{fluent-field-id-FIELD_NAME}} pattern where FIELD_NAME
+         * is the Fluent Forms field element name.
+         *
+         * @since 2.0.3
+         *
+         * @param string $doc_title Document title that may contain placeholders.
+         * @param int    $doc_id    Document ID.
+         *
+         * @return string Document title with Fluent Forms field values.
+         */
+        public function fluent_document_title_filter($doc_title, $doc_id) {
+
+            $form_integration = WP_E_Sig()->document->getFormIntegration($doc_id);
+            if ("fluentform" !== $form_integration) {
+                return $doc_title;
+            }
+
+            preg_match_all('/{{fluent-field-id-([^}]+)}}/', $doc_title, $matches_all, PREG_SET_ORDER);
+
+            if (empty($matches_all)) {
+                return $doc_title;
+            }
+
+            $fluent_value = $this->get_submission_value($doc_id);
+            if (!is_array($fluent_value)) {
+                return $doc_title;
+            }
+
+            foreach ($matches_all as $match) {
+                $placeholder = $match[0];
+                $field_id    = !empty($match[1]) ? sanitize_text_field($match[1]) : false;
+
+                if (!$field_id || !array_key_exists($field_id, $fluent_value)) {
+                    continue;
+                }
+
+                $field_value = $this->normalize_title_value($fluent_value[$field_id]);
+                if ('' === $field_value) {
+                    continue;
+                }
+
+                // Security: Escape value to prevent XSS in document title.
+                $doc_title = str_replace($placeholder, esc_html($field_value), $doc_title);
+            }
+
+            return $doc_title;
+        }
+
+        /**
+         * Get saved Fluent Forms submission values for a document.
+         *
+         * @since 2.0.3
+         * @access private
+         *
+         * @param int $doc_id Document ID.
+         *
+         * @return array|bool Submission values, or false when unavailable.
+         */
+        private function get_submission_value($doc_id) {
+
+            $submission_value = WP_E_Sig()->meta->get($doc_id, "esig_fluent_forms_submission_value");
+
+            if (empty($submission_value)) {
+                return false;
+            }
+
+            if (is_array($submission_value)) {
+                return $submission_value;
+            }
+
+            $decoded_value = json_decode($submission_value, true);
+
+            if (!is_array($decoded_value)) {
+                return false;
+            }
+
+            return $decoded_value;
+        }
+
+        /**
+         * Convert a submitted field value into title-safe plain text.
+         *
+         * @since 2.0.3
+         * @access private
+         *
+         * @param mixed $value Submitted field value.
+         *
+         * @return string Plain text field value.
+         */
+        private function normalize_title_value($value) {
+
+            if (is_scalar($value)) {
+                return sanitize_text_field((string) $value);
+            }
+
+            if (is_array($value)) {
+                $items = array();
+
+                foreach ($value as $item) {
+                    $item = $this->normalize_title_value($item);
+                    if ('' !== $item) {
+                        $items[] = $item;
+                    }
+                }
+
+                return implode(' ', $items);
+            }
+
+            return '';
         }
 
         /**


### PR DESCRIPTION
Trello: https://trello.com/c/QeO4EuXw

## Summary
- Adds Fluent Forms document title placeholder support for `{{fluent-field-id-FIELD_NAME}}`.
- Replaces placeholders with saved Fluent submission values when cloned WP E-Signature documents are titled.
- Sanitizes and escapes replacement values before they are used in document titles.

## Test plan
- ✅ PHP syntax check passed for the edited file.
- ✅ Security PHPCS scan passed for the edited file.
- ✅ Manually tested and visually verified by developer.
- ⏭ E2E skipped — covered by unit/syntax/security checks and manual verification.

## Security Checklist
- [x] Inputs sanitized
- [x] Outputs escaped
- [x] Nonces verified where applicable
- [x] Capabilities checked where applicable
- [x] No hardcoded credentials
- [x] Automated scan passed