### PR TITLE
TRL-1623: Guard Fluent Forms inaccessible SAD pages

### DIFF
--- a/admin/esig-ffds-admin.php
+++ b/admin/esig-ffds-admin.php
@@ -436,6 +436,20 @@ if (!class_exists('ESIG_FFDS_Admin')):
 
 
 
+        /**
+         * Creates a signature agreement from an eligible Fluent Forms submission.
+         *
+         * Skips agreement creation when the linked Stand Alone Document page is
+         * unavailable, trashed, or drafted.
+         *
+         * @since 2.0.3
+         *
+         * @param int    $insertId Submitted Fluent Forms entry ID.
+         * @param array  $formData Submitted Fluent Forms field data.
+         * @param object $form     Fluent Forms form object.
+         *
+         * @return bool|void False when submission is ineligible; otherwise void.
+         */
         public function fluentform_submission($insertId, $formData, $form)
         {
 
@@ -466,6 +480,13 @@ if (!class_exists('ESIG_FFDS_Admin')):
 
             if (is_array($signer_name)) {
                 $signer_name = sanitize_text_field(esigFluentSetting::prepareNames($signer_name));
+            }
+
+            // Skip agreement creation when the linked SAD page is inaccessible.
+            // The core helper blocks deleted, trashed, and drafted pages while
+            // allowing all other valid WordPress page statuses. See TRL-1623.
+            if ( function_exists( 'esig_is_page_accessible' ) && ! esig_is_page_accessible( (int) $sad_page_id ) ) {
+                return false;
             }
 
             $document_id = $sad->get_sad_id($sad_page_id);

--- a/includes/fluentEsigSettings.php
+++ b/includes/fluentEsigSettings.php
@@ -6,7 +6,17 @@ use WP_E_Invite;
 
 class esigFluentSetting {
 
-        
+    /**
+     * Builds the Stand Alone Document options for Fluent Forms feed settings.
+     *
+     * Published and private pages are listed normally. Inaccessible pages remain
+     * listed with their status so existing feed selections are preserved and an
+     * administrator can see which page needs attention.
+     *
+     * @since 2.0.3
+     *
+     * @return array|null SAD page IDs mapped to their display titles, or null when E-Signature is unavailable.
+     */
     public static function get_sad_documents()
     {
         if (!function_exists('WP_E_Sig'))
@@ -29,14 +39,24 @@ class esigFluentSetting {
         foreach ($sad_pages as $page) {
             $document_status = $api->document->getStatus($page->document_id);
 
-            if ($document_status != 'trash') {
-                if ('publish' === get_post_status($page->page_id) || 'private' === get_post_status($page->page_id)) {
-                    $choices[$page->page_id] = get_the_title($page->page_id);
-                    
-                }
+            if ($document_status === 'trash') {
+                continue;
             }
 
-            
+            $title = get_the_title($page->page_id);
+            if (!$title) {
+                continue;
+            }
+
+            // Preserve pages with inaccessible statuses so existing feed mappings
+            // remain selected and clearly show the issue. See TRL-1622, TRL-1623.
+            $page_status = get_post_status((int) $page->page_id);
+            if (!in_array($page_status, array('publish', 'private'), true)) {
+                $status_label = $page_status ? ucfirst($page_status) : __('Deleted', 'esig-FFDS');
+                $title        = $title . ' [' . $status_label . ']';
+            }
+
+            $choices[$page->page_id] = $title;
         }
 
         return $choices;


### PR DESCRIPTION
Trello: https://trello.com/c/mCQcdvyW

## Summary
- Preserve inaccessible SAD pages in Fluent Forms feed settings with status labels.
- Prevent agreement creation and redirects for inaccessible linked pages through the shared core helper.

## Testing
- ✅ Manually tested and visually verified by developer
- ⏭ E2E skipped — covered by syntax and lint checks

## Security Checklist
- [x] Inputs sanitized
- [x] Outputs escaped
- [x] Nonces verified (not applicable)
- [x] Capabilities checked (not applicable)
- [x] No hardcoded credentials
- [ ] Automated scan passed (tooling unavailable in this add-on)