### PR TITLE
TRL-1610: Migrate Fluent Forms bridge off esig_global_document_id option

### DIFF
--- a/admin/esig-ffds-admin.php
+++ b/admin/esig-ffds-admin.php
@@ -189,6 +189,12 @@ if (!class_exists('ESIG_FFDS_Admin')):
          * field values are still populated correctly. This mirrors the pattern used by
          * all other bridge plugins (Gravity, WPForms, Formidable, Forminator, Ninja).
          *
+         * Document ID lookup priority:
+         *   1. csum URL param          — always present on the signing page.
+         *   2. document_id URL param   — present on admin preview URLs (?esigpreview=1&document_id=X).
+         *   3. Document::current_document_id() stack — set by esig_do_shortcode() via TRL-1608.
+         *   4. esig_global_document_id option — legacy fallback when core stack is unavailable.
+         *
          * @since  2.0.1
          * @access public
          *
@@ -228,40 +234,41 @@ if (!class_exists('ESIG_FFDS_Admin')):
              * When the contract is opened in a new HTTP request (email invite / redirect)
              * the in-memory globals are null. Load saved submission data from document meta.
              *
-             * Lookup priority:
-             *   1. csum URL param   — always present on the signing page.
-             *   2. document_id param — present on admin preview URLs (?esigpreview=1&document_id=X).
-             *   3. esig_global_document_id option — fallback set by esig_do_shortcode().
-             *
              * This matches the established pattern used by WPForms, Forminator, and other
              * bridge plugins so that preview of a submitted document shows real values.
              */
-            if ( is_null($newFormId) || empty($esigFluentFormdata) ) {
-                if ( function_exists('WP_E_Sig') ) {
-                    $csum        = esigget('csum');
+            if ( is_null( $newFormId ) || empty( $esigFluentFormdata ) ) {
+                if ( function_exists( 'WP_E_Sig' ) ) {
+                    $csum        = esigget( 'csum' );
                     $document_id = 0;
 
-                    if ( ! empty($csum) ) {
-                        $document_id = WP_E_Sig()->document->document_id_by_csum($csum);
+                    if ( ! empty( $csum ) ) {
+                        $document_id = WP_E_Sig()->document->document_id_by_csum( $csum );
                     }
 
                     if ( ! $document_id ) {
-                        $document_id = absint( esigget('document_id') );
+                        $document_id = absint( esigget( 'document_id' ) );
                     }
 
                     if ( ! $document_id ) {
-                        $document_id = get_option('esig_global_document_id');
+                        // Prefer the request-scoped stack (TRL-1608/TRL-1610); fall back to
+                        // the legacy DB option when the core stack class is unavailable.
+                        if ( class_exists( '\WpEsignature\Models\Document' ) ) {
+                            $document_id = \WpEsignature\Models\Document::current_document_id();
+                        } else {
+                            $document_id = get_option( 'esig_global_document_id' );
+                        }
                     }
 
                     if ( $document_id ) {
-                        $saved_form_id = WP_E_Sig()->meta->get($document_id, 'esig_ff_form_id');
-                        if ($saved_form_id) {
-                            self::setFluentFormID($saved_form_id);
+                        $saved_form_id = WP_E_Sig()->meta->get( $document_id, 'esig_ff_form_id' );
+                        if ( $saved_form_id ) {
+                            self::setFluentFormID( $saved_form_id );
                             $newFormId = $saved_form_id;
                         }
-                        $saved_submission = WP_E_Sig()->meta->get($document_id, 'esig_fluent_forms_submission_value');
-                        if ($saved_submission) {
-                            $esigFluentFormdata = json_decode($saved_submission, true);
+                        $saved_submission = WP_E_Sig()->meta->get( $document_id, 'esig_fluent_forms_submission_value' );
+                        if ( $saved_submission ) {
+                            $esigFluentFormdata = json_decode( $saved_submission, true );
                         }
                     }
                 }

--- a/admin/esig-fluent-filters.php
+++ b/admin/esig-fluent-filters.php
@@ -176,32 +176,37 @@ if (!class_exists('esigFluentFilters')):
         }
 
         /**
-         *  Render document to replace shortcodes 
-         *  @since 1.5.6.8
-         *  @param string $content | content of document which will be replaced 
-         *  @param int $new_doc_id | new document after cloning existing agreement. 
-         *  @param string $documentType | Type of document  
-         *  @param array $args | Different types of argument pass 
-         *  @return {string}  | Return replace content of shortcodes.
+         * Render document content by replacing [esigfluent] shortcodes with submitted field values.
+         *
+         * Migrated in TRL-1610 off the shared esig_global_document_id WordPress option to the
+         * request-scoped static stack introduced in TRL-1608. The document ID is pushed onto
+         * the stack before shortcode processing and popped immediately after, eliminating the
+         * concurrency hazard that the option-based approach carried.
+         *
+         * @since 1.5.6.8
+         *
+         * @param string $content      Document content containing shortcodes to replace.
+         * @param int    $new_doc_id   ID of the newly cloned document being rendered.
+         * @param string $documentType Type of document (e.g. 'stand_alone').
+         * @param array  $args         Render arguments including integrationType.
+         *
+         * @return string Document content with shortcodes replaced by submission values.
          */
+        public function document_content_render( $content, $new_doc_id, $documentType, $args ) {
 
-        public function document_content_render($content, $new_doc_id, $documentType, $args) {
-
-            if ($documentType != 'stand_alone') {
+            if ( 'stand_alone' !== $documentType ) {
                 return $content;
             }
 
-             update_option('esig_global_document_id', $new_doc_id, false);
+            $isIntregration = esigget( 'integrationType', $args );
 
-            $isIntregration = esigget("integrationType", $args);
-
-            if ($isIntregration != "esigfluent") {
-               
+            if ( 'esigfluent' !== $isIntregration ) {
                 return $content;
             }
-            $content = $this->replace_shortcode($content, $args);   
 
-            delete_option('esig_global_document_id');
+            \WpEsignature\Models\Document::push_document_context( $new_doc_id );
+            $content = $this->replace_shortcode( $content, $args );
+            \WpEsignature\Models\Document::pop_document_context();
 
             return $content;
         }


### PR DESCRIPTION
Trello: https://trello.com/c/o0JPNAoU

## Summary

Migrates the Fluent Forms bridge plugin off the shared `esig_global_document_id` WordPress option (a concurrency hazard identified in TRL-1608) to the request-scoped static stack introduced in that phase.

**Changes:**
- `admin/esig-fluent-filters.php` — `document_content_render()`: removed `update_option`/`delete_option` calls; wraps shortcode processing with `Document::push_document_context()` / `pop_document_context()` instead.
- `admin/esig-ffds-admin.php` — `render_shortcode_esigfluent()`: replaced `get_option('esig_global_document_id')` fallback with `Document::current_document_id()`; retains `get_option` as a defensive fallback when the core stack class is unavailable.
- Also fixes a secondary bug where `delete_option` was missing on the early-return path in `document_content_render()`.

## Security Checklist
- [x] Inputs sanitized
- [x] Outputs escaped
- [x] Nonces verified
- [x] Capabilities checked
- [x] No hardcoded credentials
- [x] Automated scan passed

## Testing
✅ Manually tested and visually verified by developer
⏭ E2E skipped — covered by unit tests