### PR TITLE
TRL-1644: guard current_document_id() with method_exists()

### DIFF
--- a/admin/esig-ffds-admin.php
+++ b/admin/esig-ffds-admin.php
@@ -252,8 +252,9 @@ if (!class_exists('ESIG_FFDS_Admin')):
 
                     if ( ! $document_id ) {
                         // Prefer the request-scoped stack (TRL-1608/TRL-1610); fall back to
-                        // the legacy DB option when the core stack class is unavailable.
-                        if ( class_exists( '\WpEsignature\Models\Document' ) ) {
+                        // the legacy DB option when the core stack class/method is unavailable
+                        // (TRL-1644 — older core builds predating TRL-1608).
+                        if ( class_exists( '\WpEsignature\Models\Document' ) && method_exists( '\WpEsignature\Models\Document', 'current_document_id' ) ) {
                             $document_id = \WpEsignature\Models\Document::current_document_id();
                         } else {
                             $document_id = get_option( 'esig_global_document_id' );


### PR DESCRIPTION
Trello: https://trello.com/c/j1fLLjSs

## Summary
- Hardens the `current_document_id()` call site against an e-signature core build predating TRL-1608 (< 2.1.5), where the method does not exist yet.
- Adds `method_exists()` alongside the existing `class_exists()` check, falling through to the legacy `esig_global_document_id` option instead of fataling.
- Companion fix to TRL-1643 (CF7 add-on, already merged), extended to the remaining bridge add-ons.

## Security Checklist
- [x] Inputs sanitized (no new input handling)
- [x] Outputs escaped (no new output)
- [x] Nonces verified (n/a)
- [x] Capabilities checked (n/a)
- [x] No hardcoded credentials
- [x] Automated scan passed (defensive guard clause only)

✅ Manually tested and visually verified by developer
⏭ E2E skipped — covered by unit tests